### PR TITLE
fix: CICD에서 docker-compose파일 생성 추가

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -47,23 +47,22 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: 스프링부트 애플리케이션 빌드 # (1)
-
+      - name: 스프링부트 애플리케이션 빌드
         run: ./gradlew clean build -Pprofile=prod
 
-      - name: 도커 이미지 빌드 # (2)
+      - name: 도커 이미지 빌드
         run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/nshop-repo .
         
-      - name: Docker Hub 로그인 # (3)
+      - name: Docker Hub 로그인
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Hub 퍼블리시 # (4)
+      - name: Docker Hub 퍼블리시
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/nshop-repo
       
-      - name: EC2 접속 및 도커 컴포즈 실행
+      - name: EC2 접속 및 docker-compose.yml 파일 전송 및 실행
         uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.HOST }}
@@ -72,6 +71,7 @@ jobs:
           
           script: |
             cd /home/ubuntu
+            echo "${{ secrets.DOCKER_COMPOSE }}" > docker-compose.yml # github secrets에 설정한 DOCKER_COMPOSE 파일을 생성한다.
             docker-compose down
             docker-compose pull
             docker-compose up -d

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -75,6 +75,6 @@ jobs:
             docker-compose down
             docker-compose pull
             docker-compose up -d
-            # 현재 실행중이 아닌 12시간 이상 지난 nshop-repo가 포함된 컨테이너 이미지 삭제
-            docker images --filter "until=12h" --format '{{.Repository}}:{{.Tag}}' | grep 'nshop-repo' | xargs -I {} docker rmi {}
+            # 현재 실행중이 아닌 12시간 이상 컨테이너 이미지 삭제
+            docker image prune -f --filter "until=12h"
             

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -75,3 +75,6 @@ jobs:
             docker-compose down
             docker-compose pull
             docker-compose up -d
+            # 현재 실행중이 아닌 12시간 이상 지난 nshop-repo가 포함된 컨테이너 이미지 삭제
+            docker images --filter "until=12h" --format '{{.Repository}}:{{.Tag}}' | grep 'nshop-repo' | xargs -I {} docker rmi {}
+            


### PR DESCRIPTION
CICD에서 docker-compose파일을 github secrets로 부터 불러온 뒤 ec2 리눅스 서버에 복사하여
실행하는 것으로 변경함.